### PR TITLE
Add voice message support

### DIFF
--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -116,15 +116,19 @@ impl MessageResponse {
 
   /// Set voice message flag
   /// ```no_run
-  /// # use slashook::commands::MessageResponse;
+  /// # use slashook::commands::{MessageResponse, CmdResult};
   /// # use slashook::structs::{channels::MessageFlags, utils::File};
   /// # use slashook::tokio::fs::File as TokioFile;
+  /// # #[slashook::main]
+  /// # async fn main() -> CmdResult {
   /// let file = TokioFile::open("audio.ogg").await?;
   /// let audio_file = File::from_file("audio.ogg", file).await?
   ///   .set_duration_secs(1.1799999475479126)
   ///   .set_waveform("AAM1YAAAAAAAAAA=");
   /// let response = MessageResponse::from(audio_file).set_as_voice_message(true);
   /// assert_eq!(response.flags.unwrap().contains(MessageFlags::IS_VOICE_MESSAGE), true);
+  /// # Ok(())
+  /// # }
   /// ```
   pub fn set_as_voice_message(mut self, is_voice_message: bool) -> Self {
     let mut flags = self.flags.unwrap_or_else(MessageFlags::empty);

--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -114,6 +114,25 @@ impl MessageResponse {
     self
   }
 
+  /// Set voice message flag
+  /// ```no_run
+  /// # use slashook::commands::MessageResponse;
+  /// # use slashook::structs::{channels::MessageFlags, utils::File};
+  /// # use slashook::tokio::fs::File as TokioFile;
+  /// let file = TokioFile::open("audio.ogg").await?;
+  /// let audio_file = File::from_file("audio.ogg", file).await?
+  ///   .set_duration_secs(1.1799999475479126)
+  ///   .set_waveform("AAM1YAAAAAAAAAA=");
+  /// let response = MessageResponse::from(audio_file).set_as_voice_message(true);
+  /// assert_eq!(response.flags.unwrap().contains(MessageFlags::IS_VOICE_MESSAGE), true);
+  /// ```
+  pub fn set_as_voice_message(mut self, is_voice_message: bool) -> Self {
+    let mut flags = self.flags.unwrap_or_else(MessageFlags::empty);
+    flags.set(MessageFlags::IS_VOICE_MESSAGE, is_voice_message);
+    self.flags = Some(flags);
+    self
+  }
+
   /// Add an embed to the message
   /// ```
   /// # use slashook::commands::MessageResponse;

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -71,11 +71,9 @@ fn handle_multipart<U: Serialize + Attachments>(mut json_data: U, files: Vec<Fil
   let mut attachments = json_data.take_attachments();
 
   for (i, file) in files.into_iter().enumerate() {
+    attachments.push(Attachment::from_file(i.to_string(), &file));
     let part = Part::bytes(file.data).file_name(file.filename);
     form_data = form_data.part(format!("files[{}]", i), part);
-    if let Some(description) = file.description {
-      attachments.push(Attachment::with_description(i, description));
-    }
   }
 
   json_data.set_attachments(attachments);

--- a/src/structs/channels.rs
+++ b/src/structs/channels.rs
@@ -23,6 +23,7 @@ use super::{
   permissions::Permissions,
   stickers::StickerItem,
   users::User,
+  utils::File,
 };
 use crate::{
   rest::{Rest, RestError},
@@ -1346,11 +1347,11 @@ impl Attachment {
     }
   }
 
-  pub(crate) fn with_description<T: ToString, U: ToString>(id: T, description: U) -> Self {
+  pub(crate) fn from_file(id: Snowflake, file: &File) -> Self {
     Self {
-      id: id.to_string(),
+      id,
       filename: String::from(""),
-      description: Some(description.to_string()),
+      description: file.description.clone(),
       content_type: None,
       size: 0,
       url: String::from(""),
@@ -1358,8 +1359,8 @@ impl Attachment {
       height: None,
       width: None,
       ephemeral: None,
-      duration_secs: None,
-      waveform: None,
+      duration_secs: file.duration_secs,
+      waveform: file.waveform.clone(),
       flags: None
     }
   }

--- a/src/structs/channels.rs
+++ b/src/structs/channels.rs
@@ -550,12 +550,12 @@ bitflags! {
     /// This message will not trigger push and desktop notifications
     const SUPPRESS_NOTIFICATIONS = 1 << 12;
     /// This message is a voice message
-    const IS_VOICE_MESSAGE = 1 << 12;
+    const IS_VOICE_MESSAGE = 1 << 13;
   }
 }
 
 bitflags! {
-  /// Bitflags for Discord Message Flags
+  /// Bitflags for Discord Attachment Flags
   #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
   pub struct AttachmentFlags: u32 {
     /// This attachment has been edited using the remix feature on mobile
@@ -1364,13 +1364,13 @@ impl Attachment {
     }
   }
 
-  /// Sets the duration of the file in seconds (currently for voice messages)
+  /// Sets the duration of the file in seconds
   pub fn set_duration_secs(mut self, duration_secs: f64) -> Self {
     self.duration_secs = Some(duration_secs);
     self
   }
 
-  /// Sets the waveform of the file (currently for voice messages)
+  /// Sets the waveform of the file
   pub fn set_waveform<T: ToString>(mut self, waveform: T) -> Self {
     self.waveform = Some(waveform.to_string());
     self

--- a/src/structs/channels.rs
+++ b/src/structs/channels.rs
@@ -1364,18 +1364,6 @@ impl Attachment {
       flags: None
     }
   }
-
-  /// Sets the duration of the file in seconds
-  pub fn set_duration_secs(mut self, duration_secs: f64) -> Self {
-    self.duration_secs = Some(duration_secs);
-    self
-  }
-
-  /// Sets the waveform of the file
-  pub fn set_waveform<T: ToString>(mut self, waveform: T) -> Self {
-    self.waveform = Some(waveform.to_string());
-    self
-  }
 }
 
 impl AllowedMentions {

--- a/src/structs/utils.rs
+++ b/src/structs/utils.rs
@@ -34,7 +34,11 @@ pub struct File {
   /// The bytes in the file
   pub data: Vec<u8>,
   /// Optional alt text for the file
-  pub description: Option<String>
+  pub description: Option<String>,
+  /// The duration in seconds for a voice message
+  pub duration_secs: Option<f64>,
+  /// The waveform for a voice message
+  pub waveform: Option<String>
 }
 
 impl Color {
@@ -86,7 +90,9 @@ impl File {
     Self {
       filename: filename.to_string(),
       data: data.into(),
-      description: None
+      description: None,
+      duration_secs: None,
+      waveform: None
     }
   }
 
@@ -107,7 +113,9 @@ impl File {
     Ok(Self {
       filename: filename.to_string(),
       data,
-      description: None
+      description: None,
+      duration_secs: None,
+      waveform: None
     })
   }
 
@@ -125,6 +133,18 @@ impl File {
   /// ```
   pub fn set_description<T: ToString>(mut self, description: T) -> Self {
     self.description = Some(description.to_string());
+    self
+  }
+
+  /// Set the duration
+  pub fn set_duration_secs(mut self, duration_secs: f64) -> Self {
+    self.duration_secs = Some(duration_secs);
+    self
+  }
+
+  /// Set the waveform
+  pub fn set_waveform<T: ToString>(mut self, waveform: T) -> Self {
+    self.waveform = Some(waveform.to_string());
     self
   }
 }

--- a/src/webhook/multipart.rs
+++ b/src/webhook/multipart.rs
@@ -5,9 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::{
-  io::Cursor,
-};
+use std::io::Cursor;
 use crate::structs::{
   channels::Attachment,
   interactions::{InteractionCallback, Attachments}
@@ -37,10 +35,8 @@ pub fn handle_multipart(mut callback: InteractionCallback) -> response::Result<'
   let mut attachments = data.take_attachments();
 
   for (i, file) in files.into_iter().enumerate() {
+    attachments.push(Attachment::from_file(i.to_string(), &file));
     form.add_reader_file(format!("files[{}]", i), Cursor::new(file.data), file.filename);
-    if let Some(description) = file.description {
-      attachments.push(Attachment::with_description(i, description));
-    }
   }
 
   data.set_attachments(attachments);


### PR DESCRIPTION
This commit adds the new properties for voice messages and functions to the `Attachment` struct. `AttachmentFlags` is also added as an extra.