### PR TITLE
Make sure options aren't serialized in queries

### DIFF
--- a/src/structs/channels.rs
+++ b/src/structs/channels.rs
@@ -433,8 +433,10 @@ pub struct ChannelModifyOptions {
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct PinsListOptions {
   /// Get messages pinned before this timestamp
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub before: Option<DateTime<Utc>>,
   /// Max number of pins to return (1-50; Defaults to 50)
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
 }
 
@@ -471,10 +473,13 @@ pub struct ThreadCreateOptions {
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct ThreadMemberOptions {
   /// Whether to include a [guild member](GuildMember) object for each thread member
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub with_member: Option<bool>,
   /// Get thread members after this user ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub after: Option<Snowflake>,
   /// Max number of thread members to return (1-100). Defaults to 100.
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
 }
 
@@ -482,8 +487,10 @@ pub struct ThreadMemberOptions {
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct ThreadListOptions {
   /// Returns threads archived before this timestamp
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub before: Option<DateTime<Utc>>,
   /// Optional maximum number of threads to return
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
 }
 

--- a/src/structs/guilds.rs
+++ b/src/structs/guilds.rs
@@ -739,6 +739,7 @@ pub enum GuildOnboardingMode {
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct GuildFetchOptions {
   /// when `true`, will return approximate member and presence counts for the guild
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub with_counts: Option<bool>,
 }
 

--- a/src/structs/monetization.rs
+++ b/src/structs/monetization.rs
@@ -120,18 +120,25 @@ pub enum EntitlementType {
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct ListEntitlementsOptions {
   /// User ID to look up entitlements for
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub user_id: Option<Snowflake>,
   /// Optional comma-delimited list of SKU IDs to check entitlements for
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub sku_ids: Option<String>,
   /// Retrieve entitlements before this entitlement ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub before: Option<Snowflake>,
   /// Retrieve entitlements after this entitlement ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub after: Option<Snowflake>,
   /// Number of entitlements to return, 1-100, default 100
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
   /// Guild ID to look up entitlements for
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub guild_id: Option<Snowflake>,
   /// Whether or not ended entitlements should be omitted
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub exclude_ended: Option<bool>,
 }
 
@@ -201,12 +208,16 @@ pub enum SubscriptionStatus {
 #[derive(Serialize, Clone, Debug, Default)]
 pub struct ListSubscriptionOptions {
   /// List subscriptions before this ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub before: Option<Snowflake>,
   /// List subscriptions after this ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub after: Option<Snowflake>,
   /// Number of results to return (1-100)
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
   /// User ID for which to return subscriptions. Required except for OAuth queries.
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub user_id: Option<Snowflake>,
 }
 

--- a/src/structs/users.rs
+++ b/src/structs/users.rs
@@ -143,12 +143,16 @@ pub struct ModifyUserOptions {
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct GetUserGuildsOptions {
   /// Get guilds before this guild ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub before: Option<Snowflake>,
   /// Get guilds after this guild ID
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub after: Option<Snowflake>,
   /// Max number of guilds to return (1-200). Default 200
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub limit: Option<i64>,
   /// Include approximate member and presence counts in response
+  #[serde(skip_serializing_if = "Option::is_none")]
   pub with_counts: Option<bool>,
 }
 


### PR DESCRIPTION
Seems like that was already done by `serde_urlencoded` used by reqwest before, but with the switch to `serde_qs` for array support, field names started to be present without a value